### PR TITLE
Remove recompile_invalidations

### DIFF
--- a/src/FastAlmostBandedMatrices.jl
+++ b/src/FastAlmostBandedMatrices.jl
@@ -1,11 +1,9 @@
 module FastAlmostBandedMatrices
 
-import PrecompileTools: @recompile_invalidations, @setup_workload, @compile_workload
+import PrecompileTools: @setup_workload, @compile_workload
 
-@recompile_invalidations begin
-    using ArrayInterface, ArrayLayouts, BandedMatrices, ConcreteStructs, LazyArrays,
-          LinearAlgebra, MatrixFactorizations, Reexport
-end
+using ArrayInterface, ArrayLayouts, BandedMatrices, ConcreteStructs, LazyArrays,
+      LinearAlgebra, MatrixFactorizations, Reexport
 
 import ArrayLayouts: MemoryLayout, sublayout, sub_materialize, MatLdivVec, materialize!,
                      triangularlayout, triangulardata, zero!, _copyto!, colsupport,


### PR DESCRIPTION
`@recompile_invalidations` should only be used in very specific scenarios, and this is not one of those scenarios. Also, there are big changes being done with https://github.com/SciML/CommonWorldInvalidations.jl. With that, we only need to `@recompile_invalidations` on a few entry points. In particular, Static.jl, Symbolics.jl, and preferably ForwardDiff.jl and StaticArrays.jl would adopt it too. But this means that in order to handle all of this effectively, in SciML we only need to apply it on Static.jl, Symbolics.jl, and SciMLBase.jl and the whole ecosystem should be fine.

In any case, this library doesn't need it. It shouldn't make a tangible difference in compile times, while it increases precompile times by a lot.

## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
