### PR TITLE
Fix format-pr workflow permissions

### DIFF
--- a/.github/workflows/FormatPR.yml
+++ b/.github/workflows/FormatPR.yml
@@ -5,6 +5,9 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
       - name: Install JuliaFormatter and format


### PR DESCRIPTION
## Summary
- Add `contents: write` and `pull-requests: write` permissions to the `format-pr` workflow job

The `peter-evans/create-pull-request` action needs write permissions to push the formatting branch and create PRs. GitHub's default `GITHUB_TOKEN` permissions were changed to read-only, causing daily 403 errors on the push step.

## Test plan
- [ ] Verify the format-pr workflow can successfully push and create PRs after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)