### PR TITLE
Centralize CI on SciML reusable workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,3 @@ updates:
       all-julia-packages:
         patterns:
           - "*"
-    ignore:
-      - dependency-name: "crate-ci/typos"
-        update-types: ["version-update:semver-patch", "version-update:semver-minor"]

--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -11,22 +11,10 @@ on:
     paths-ignore:
       - 'docs/**'
 jobs:
-  test:
+  downgrade:
     if: false  # Disabled: waiting on dependency updates. See issue for details.
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        downgrade_mode: ['alldeps']
-        julia-version: ['1.10']
-    steps:
-      - uses: actions/checkout@v4
-      - uses: julia-actions/setup-julia@v2
-        with:
-          version: ${{ matrix.julia-version }}
-      - uses: julia-actions/julia-downgrade-compat@v2
-        with:
-          skip: Pkg,TOML
-      - uses: julia-actions/julia-buildpkg@v1
-      - uses: julia-actions/julia-runtest@v1
-        with:
-          ALLOW_RERESOLVE: false
+    uses: "SciML/.github/.github/workflows/downgrade.yml@v1"
+    with:
+      julia-version: "1.10"
+      skip: "Pkg,TOML"
+    secrets: "inherit"

--- a/.github/workflows/Downstream.yml
+++ b/.github/workflows/Downstream.yml
@@ -12,53 +12,18 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
 jobs:
-  test:
+  downstream:
     name: ${{ matrix.package.repo }}/${{ matrix.package.group }}
-    runs-on: ${{ matrix.os }}
-    env:
-      GROUP: ${{ matrix.package.group }}
     strategy:
       fail-fast: false
       matrix:
-        julia-version: ["1"]
-        os: [ubuntu-latest]
         package:
           - { user: SciML, repo: BoundaryValueDiffEq.jl, group: All }
-    steps:
-      - uses: actions/checkout@v4
-      - uses: julia-actions/setup-julia@v2
-        with:
-          version: ${{ matrix.julia-version }}
-          arch: x64
-      - uses: julia-actions/julia-buildpkg@v1
-      - name: Clone Downstream
-        uses: actions/checkout@v4
-        with:
-          repository: ${{ matrix.package.user }}/${{ matrix.package.repo }}
-          path: downstream
-      - name: Load this and run the downstream tests
-        shell: julia --code-coverage=user --color=yes --project=downstream {0}
-        run: |
-          using Pkg
-          try
-            # force it to use this PR's version of the package
-            Pkg.develop(PackageSpec(path="."))  # resolver may fail with main deps
-            Pkg.update()
-            Pkg.test()  # resolver may fail with test time deps
-          catch err
-            err isa Pkg.Resolve.ResolverError || rethrow()
-            # If we can't resolve that means this is incompatible by SemVer and this is fine
-            # It means we marked this as a breaking change, so we don't need to worry about
-            # Mistakenly introducing a breaking change, as we have intentionally made one
-            @info "Not compatible with this release. No problem." exception=err
-            exit(0)  # Exit immediately, as a success
-          end
-        env:
-          RETESTITEMS_NWORKERS: 4
-          RETESTITEMS_NWORKER_THREADS: 2
-      - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v5
-        with:
-          files: lcov.info
-          token: ${{ secrets.CODECOV_TOKEN }}
-          fail_ci_if_error: true
+    uses: "SciML/.github/.github/workflows/downstream.yml@v1"
+    with:
+      julia-version: "1"
+      os: "ubuntu-latest"
+      owner: "${{ matrix.package.user }}"
+      repo: "${{ matrix.package.repo }}"
+      group: "${{ matrix.package.group }}"
+    secrets: "inherit"

--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -11,12 +11,5 @@ on:
 
 jobs:
   runic:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: julia-actions/setup-julia@v2
-        with:
-          version: '1'
-      - uses: fredrikekre/runic-action@v1
-        with:
-          version: '1'
+    uses: "SciML/.github/.github/workflows/runic.yml@v1"
+    secrets: "inherit"

--- a/.github/workflows/SpellCheck.yml
+++ b/.github/workflows/SpellCheck.yml
@@ -4,10 +4,5 @@ on: [pull_request]
 
 jobs:
   typos-check:
-    name: Spell Check with Typos
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Actions Repository
-        uses: actions/checkout@v4
-      - name: Check spelling
-        uses: crate-ci/typos@v1.42.0
+    uses: "SciML/.github/.github/workflows/spellcheck.yml@v1"
+    secrets: "inherit"


### PR DESCRIPTION
Please ignore until reviewed by @ChrisRackauckas.

Converts the remaining inline CI to the centralized `SciML/.github` reusable workflows (pinned `@v1`, `secrets: "inherit"` on every caller). Behavior and matrices are preserved exactly.

## Converted (inline -> central)
- **Downgrade.yml**: inline `julia-downgrade-compat` -> `downgrade.yml@v1` (preserves Julia `1.10`, `skip: Pkg,TOML`, and the disabling `if: false`).
- **Downstream.yml**: inline downstream test -> matrix of `downstream.yml@v1` callers (preserves `SciML/BoundaryValueDiffEq.jl` group `All`).
- **FormatCheck.yml**: inline `fredrikekre/runic-action` -> `runic.yml@v1`.
- **SpellCheck.yml**: inline `crate-ci/typos` -> `spellcheck.yml@v1`.

## Unchanged
- **Tests.yml**: already a `tests.yml@v1` caller with `secrets: "inherit"` (version x os matrix preserved).
- **TagBot.yml**: left as-is.
- **FormatPR.yml**: left as-is (legacy JuliaFormatter auto-PR bot; out of scope for this conversion). Note it formats with JuliaFormatter while the format check now uses Runic, so it may be worth removing separately.

## Other
- **dependabot.yml**: removed the `crate-ci/typos` ignore entry. `github-actions` (`/`, weekly) and `julia` (`/`, `/test`, daily, group `all-julia-packages` `["*"]`) blocks preserved.
- No `docs/` directory, so no Documentation caller added.

## Checks
- Runic: ran `Runic.main(["--inplace", ...])` locally; no formatting changes (repo already Runic-clean).
- typos: `typos .` exits 0 (clean); no fixes needed. Existing `.typos.toml` is respected by `spellcheck.yml@v1`.

## Warning
Check names will change (jobs now run through reusable workflows, e.g. "Runic Format Check", "Spell Check with Typos", "Downgrade Tests", "Downstream Tests"). Branch-protection required-status-check names will need updating accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)