### PR TITLE
Canonical CI cleanup: TagBot thin-caller + downgrade-caller cleanup

### DIFF
--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -14,6 +14,5 @@ jobs:
   downgrade:
     uses: "SciML/.github/.github/workflows/downgrade.yml@v1"
     with:
-      julia-version: "1.10"
-      skip: "Pkg,TOML"
+      julia-version: "lts"
     secrets: "inherit"

--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -1,31 +1,9 @@
-name: TagBot
+name: "TagBot"
 on:
   issue_comment:
-    types:
-      - created
+    types: [created]
   workflow_dispatch:
-    inputs:
-      lookback:
-        default: "3"
-permissions:
-  actions: read
-  checks: read
-  contents: write
-  deployments: read
-  issues: read
-  discussions: read
-  packages: read
-  pages: read
-  pull-requests: read
-  repository-projects: read
-  security-events: read
-  statuses: read
 jobs:
-  TagBot:
-    if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: JuliaRegistries/TagBot@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          ssh: ${{ secrets.DOCUMENTER_KEY }}
+  tagbot:
+    uses: "SciML/.github/.github/workflows/tagbot.yml@v1"
+    secrets: "inherit"


### PR DESCRIPTION
- **TagBot.yml**: replaced the inlined `JuliaRegistries/TagBot@v1` workflow (with its permissions block) with the canonical thin caller `SciML/.github/.github/workflows/tagbot.yml@v1`.
- **Downgrade.yml**: removed the hand-listed `skip: "Pkg,TOML"` input (both Julia stdlibs, now auto-populated centrally); changed `julia-version: "1.10"` -> `"lts"`.

Not a monorepo (no `lib/` subpackages).

Ignore until reviewed by @ChrisRackauckas.