### PR TITLE
Fix flaky zero-allocation tests on Julia 1.12+ via AllocCheck.check_allocs

### DIFF
--- a/test/alloc_tests.jl
+++ b/test/alloc_tests.jl
@@ -1,48 +1,36 @@
 using AllocCheck
-using BenchmarkTools
 using FastAlmostBandedMatrices
 using FastAlmostBandedMatrices: DisjointRange
 using ArrayLayouts: colsupport, rowsupport
 using Test
 
+# Allocation freedom is verified with `AllocCheck.check_allocs`, which statically
+# proves the absence of any allocating code path for the given argument types.
+# This is immune to the first-call compilation and global-scope boxing noise that
+# `@allocated` picks up on newer Julia versions, so it directly tests the intended
+# invariant (the operation never allocates) rather than a single runtime sample.
+
+getidx(A, i...) = A[i...]
+setidx!(A, v, i...) = (A[i...] = v; nothing)
+function sumiter(d)
+    s = zero(eltype(d))
+    for x in d
+        s += x
+    end
+    return s
+end
+
 @testset "Allocation Tests" begin
     @testset "DisjointRange - Zero Allocations" begin
-        # Test that DisjointRange operations don't allocate
         r1 = Base.OneTo(5)
         r2 = 10:15
         dr = DisjointRange(r1, r2)
 
-        # Test length
-        allocs = @allocated length(dr)
-        @test allocs == 0
-
-        # Test getindex
-        allocs = @allocated dr[3]
-        @test allocs == 0
-
-        allocs = @allocated dr[8]
-        @test allocs == 0
-
-        # Test first/last
-        allocs = @allocated first(dr)
-        @test allocs == 0
-
-        allocs = @allocated last(dr)
-        @test allocs == 0
-
-        # Test iteration (after warmup)
-        sum_test = 0
-        for x in dr
-            sum_test += x
-        end
-        allocs = @allocated begin
-            s = 0
-            for x in dr
-                s += x
-            end
-            s
-        end
-        @test allocs == 0
+        @test isempty(check_allocs(length, (typeof(dr),)))
+        @test isempty(check_allocs(getidx, (typeof(dr), Int)))
+        @test isempty(check_allocs(first, (typeof(dr),)))
+        @test isempty(check_allocs(last, (typeof(dr),)))
+        @test isempty(check_allocs(sumiter, (typeof(dr),)))
     end
 
     @testset "colsupport - Zero Allocations" begin
@@ -52,17 +40,9 @@ using Test
         F = rand(Float64, m, n)
         A = AlmostBandedMatrix(B, F)
 
-        # Warmup
-        colsupport(A, 5)
-        colsupport(A, 50)
-
-        # Test colsupport for j <= l+u (should return OneTo, no allocation)
-        allocs = @allocated colsupport(A, 5)
-        @test allocs == 0
-
-        # Test colsupport for j > l+u (now returns DisjointRange instead of vcat)
-        allocs = @allocated colsupport(A, 50)
-        @test allocs == 0
+        # colsupport returns OneTo for j <= l+u and a DisjointRange otherwise; both
+        # branches must be allocation-free.
+        @test isempty(check_allocs(colsupport, (typeof(A), Int)))
     end
 
     @testset "rowsupport - Zero Allocations" begin
@@ -72,16 +52,7 @@ using Test
         F = rand(Float64, m, n)
         A = AlmostBandedMatrix(B, F)
 
-        # Warmup
-        rowsupport(A, 1)
-        rowsupport(A, 50)
-
-        # Test rowsupport (always returns UnitRange, no allocation)
-        allocs = @allocated rowsupport(A, 1)
-        @test allocs == 0
-
-        allocs = @allocated rowsupport(A, 50)
-        @test allocs == 0
+        @test isempty(check_allocs(rowsupport, (typeof(A), Int)))
     end
 
     @testset "getindex/setindex! - Zero Allocations" begin
@@ -91,25 +62,8 @@ using Test
         F = rand(Float64, m, n)
         A = AlmostBandedMatrix(B, F)
 
-        # Warmup
-        _ = A[50, 50]
-        A[50, 50] = 1.0
-
-        # Test getindex
-        allocs = @allocated A[50, 50]
-        @test allocs == 0
-
-        # Test setindex! in band part
-        allocs = @allocated A[50, 50] = 2.0
-        @test allocs == 0
-
-        # Test setindex! in fill part
-        allocs = @allocated A[1, 50] = 3.0
-        @test allocs == 0
-
-        # Test setindex! in overlapping part
-        allocs = @allocated A[1, 1] = 4.0
-        @test allocs == 0
+        @test isempty(check_allocs(getidx, (typeof(A), Int, Int)))
+        @test isempty(check_allocs(setidx!, (typeof(A), Float64, Int, Int)))
     end
 
     @testset "bandpart/fillpart - Zero Allocations" begin
@@ -119,16 +73,7 @@ using Test
         F = rand(Float64, m, n)
         A = AlmostBandedMatrix(B, F)
 
-        # Warmup
-        bandpart(A)
-        fillpart(A)
-
-        # Test bandpart
-        allocs = @allocated bandpart(A)
-        @test allocs == 0
-
-        # Test fillpart
-        allocs = @allocated fillpart(A)
-        @test allocs == 0
+        @test isempty(check_allocs(bandpart, (typeof(A),)))
+        @test isempty(check_allocs(fillpart, (typeof(A),)))
     end
 end


### PR DESCRIPTION
## Problem

The `Core` test group is red on `main` across every platform (macOS, Ubuntu, Windows) and on both Julia `1` (1.12.6) and `pre` (1.13.0-rc1). The failures are all in `test/alloc_tests.jl`:

```
DisjointRange - Zero Allocations: Test Failed at test/alloc_tests.jl:21
  Evaluated: 739144 == 0
DisjointRange - Zero Allocations: Test Failed at test/alloc_tests.jl:45
  Evaluated: 704 == 0
getindex/setindex! - Zero Allocations: Test Failed at test/alloc_tests.jl:100
  Evaluated: 16 == 0
```

## Root cause

These are **`@allocated` measurement artifacts on Julia 1.12+, not real allocations in the package.** `@allocated` measures the allocations of a single runtime call, which conflates first-call compilation and global-scope boxing with genuine heap allocation:

- **Line 21 (`dr[8]`)** — the second-range branch of `DisjointRange` getindex is *never warmed up* before this `@allocated` (only `dr[3]`, the first-range branch, runs at line 20), so it measures ~700 KB of first-call compilation.
- **Line 45 (iteration)** — the accumulator `s` lives in the global scope of the `@allocated begin ... end` block, so it is boxed (704 bytes). That is an artifact of measuring outside a function, not of the `iterate` methods.
- **Line 100 (`A[50, 50]`)** — even after one warmup call, the first `@allocated` captured residual specialization allocations (16 bytes).

The package targeted Julia 1.10/1.11 CI when these tests were written; they passed there and only began failing as CI moved to Julia 1.12/1.13.

## Fix

Rewrite the tests to use `AllocCheck.check_allocs` (a test dependency that was already declared but unused). `check_allocs` *statically* proves the absence of any allocating code path for the given argument types — it is immune to compilation and global-scope boxing noise and is a strictly **stronger** guarantee than `@allocated == 0`. This is not a loosening: the same intended invariant (the operation never allocates) is verified more rigorously.

## Local verification

`check_allocs` reports **0 allocation sites** for every operation, confirming the package code is genuinely allocation-free; only the test methodology was flaky. Running `test/alloc_tests.jl` after the change:

| Julia | Result (before) | Result (after) |
| --- | --- | --- |
| 1.10.11 | 16/16 pass | 11/11 pass |
| 1.12.6 | 13 pass, **3 fail** | 11/11 pass |
| 1.13.0-rc1 | 13 pass, **3 fail** | 11/11 pass |

Full `Core` group via the real `SciMLTesting.run_tests()` harness on 1.12.6:

```
Test Summary:       | Pass  Total   Time
Core/alloc_tests.jl |   11     11  23.0s
Test Summary:      | Pass  Broken  Total  Time
Core/core_tests.jl |   28       2     30  9.6s   (2 pre-existing @test_broken, unchanged)
```

Runic format check on the changed file passes (exit 0).

---

Please ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
