### PR TITLE
QA: run_qa v1.6 form + ExplicitImports

### DIFF
--- a/src/FastAlmostBandedMatrices.jl
+++ b/src/FastAlmostBandedMatrices.jl
@@ -5,12 +5,12 @@ import PrecompileTools: @setup_workload, @compile_workload
 using ArrayInterface, ArrayLayouts, BandedMatrices, ConcreteStructs, LazyArrays,
     LinearAlgebra, MatrixFactorizations, Reexport
 
-import ArrayLayouts: MemoryLayout, sublayout, sub_materialize, MatLdivVec, materialize!,
-    triangularlayout, triangulardata, zero!, _copyto!, colsupport,
-    rowsupport, _qr, _qr!, _factorize, muladd!
-import BandedMatrices: _banded_qr!, bandeddata, banded_qr_lmul!
+import ArrayLayouts: MemoryLayout, sublayout, MatLdivVec, materialize!,
+    triangularlayout, triangulardata, colsupport,
+    rowsupport, _qr, _qr!, _factorize, muladd!, QRPackedQLayout, AdjQRPackedQLayout
+import BandedMatrices: _banded_qr!, banded_qr_lmul!
 import LinearAlgebra: ldiv!
-import MatrixFactorizations: QR, QRPackedQ, getQ, getR, QRPackedQLayout, AdjQRPackedQLayout
+import MatrixFactorizations: QR, QRPackedQ, getQ, getR
 
 @reexport using BandedMatrices
 

--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -1,5 +1,4 @@
 [deps]
-Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 FastAlmostBandedMatrices = "9d29842c-ecb8-4973-b1e9-a27b1157504e"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
@@ -9,8 +8,7 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 FastAlmostBandedMatrices = {path = "../.."}
 
 [compat]
-Aqua = "0.8.14"
 SafeTestsets = "0.0.1, 0.1"
-SciMLTesting = "1"
+SciMLTesting = "1.6"
 Test = "1"
 julia = "1.10"

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -1,5 +1,38 @@
-using Aqua, FastAlmostBandedMatrices, Test
+using SciMLTesting, FastAlmostBandedMatrices, Test
 
-@testset "Aqua Q/A" begin
-    Aqua.test_all(FastAlmostBandedMatrices; ambiguities = false)
-end
+run_qa(
+    FastAlmostBandedMatrices;
+    explicit_imports = true,
+    # 19 method ambiguities, all in FastAlmostBandedMatrices' own ldiv!/__arguments
+    # against ArrayLayouts/LinearAlgebra Triangular/Factorization methods.
+    # https://github.com/SciML/FastAlmostBandedMatrices.jl/issues/71
+    aqua_broken = (:ambiguities,),
+    ei_kwargs = (;
+        # Non-public names this package legitimately extends/uses from upstream:
+        # ArrayLayouts MatLdivVec/sublayout/triangulardata/triangularlayout/_qr/_qr!/
+        #   _factorize/QRPackedQLayout/AdjQRPackedQLayout, MatrixFactorizations
+        #   QR/QRPackedQ/getQ/getR, BandedMatrices _banded_qr!/banded_qr_lmul!.
+        all_explicit_imports_are_public = (;
+            ignore = (
+                :MatLdivVec, :sublayout, :triangulardata, :triangularlayout,
+                :_qr, :_qr!, :_factorize, :QRPackedQLayout, :AdjQRPackedQLayout,
+                :QR, :QRPackedQ, :getQ, :getR,
+                :_banded_qr!, :banded_qr_lmul!,
+            ),
+        ),
+        # Qualified accesses of non-public names: Base OneTo/array_summary/dims2string/
+        #   inds2string/materialize!, LinearAlgebra QRPackedQ, LazyArrays arguments,
+        #   ArrayInterface fast_scalar_indexing/qr_instance.
+        all_qualified_accesses_are_public = (;
+            ignore = (
+                :OneTo, :array_summary, :dims2string, :inds2string, :materialize!,
+                :QRPackedQ, :arguments, :fast_scalar_indexing, :qr_instance,
+            ),
+        ),
+    ),
+    # 31 names implicitly imported via the package's `using ArrayInterface, ArrayLayouts,
+    # BandedMatrices, ConcreteStructs, LazyArrays, LinearAlgebra, ...` plus
+    # `@reexport using BandedMatrices`; explicit-import conversion tracked separately.
+    # https://github.com/SciML/FastAlmostBandedMatrices.jl/issues/71
+    ei_broken = (:no_implicit_imports,),
+)


### PR DESCRIPTION
**Ignore until reviewed by @ChrisRackauckas.**

Brings the QA group onto SciMLTesting 1.6's `run_qa` v1.6 form with ExplicitImports enabled, replacing the hand-rolled `Aqua.test_all(FastAlmostBandedMatrices; ambiguities = false)` in `test/qa/qa.jl`.

## What changed

- **`test/qa/qa.jl`**: now `run_qa(FastAlmostBandedMatrices; explicit_imports = true, ...)`.
- **`src/FastAlmostBandedMatrices.jl`**: two ExplicitImports FIXes (no source-behavior change; Core tests unaffected).
- **`test/qa/Project.toml`**: drop `Aqua` (the ambiguities child-proc no longer runs, so Aqua need not be a direct dep — `run_qa` uses SciMLTesting's own Aqua); `SciMLTesting` compat -> `"1.6"`. `SafeTestsets` kept because `run_tests` wraps the group body in `@safetestset`.

## ExplicitImports findings (6 checks)

| Check | Outcome |
|---|---|
| `no_stale_explicit_imports` | **FIX** — removed 4 stale imports: `sub_materialize`, `zero!`, `_copyto!` (ArrayLayouts), `bandeddata` (BandedMatrices). |
| `all_explicit_imports_via_owners` | **FIX** — `QRPackedQLayout`/`AdjQRPackedQLayout` now imported from owner ArrayLayouts (were from re-export MatrixFactorizations). |
| `all_qualified_accesses_via_owners` | PASS. |
| `all_explicit_imports_are_public` | **IGNORE** — 15 upstream non-public names this package legitimately extends/uses (ArrayLayouts/BandedMatrices/MatrixFactorizations internal QR APIs). |
| `all_qualified_accesses_are_public` | **IGNORE** — 9 upstream non-public qualified accesses (Base `OneTo`/`array_summary`/`dims2string`/`inds2string`/`materialize!`, LinearAlgebra `QRPackedQ`, LazyArrays `arguments`, ArrayInterface `fast_scalar_indexing`/`qr_instance`). |
| `no_implicit_imports` | **BROKEN** (`ei_broken`) — 31 names via the heavy `using` set + `@reexport using BandedMatrices`; explicit-import refactor deferred. Tracked in #71. |

## Aqua

`aqua_broken = (:ambiguities,)` preserves the prior silent `ambiguities = false` disable as a visible, counted `@test_broken` placeholder. The 19 ambiguities are all in this package's own `ldiv!`/`__arguments` methods. Tracked in #71.

## Verification (released SciMLTesting v1.6.0, no dev-from-branch)

Ran the QA group exactly as CI does (`GROUP=QA`, `run_tests()`) on Julia 1.10 and 1.11:

```
Test Summary: | Pass  Broken  Total   Time
QA/qa.jl      |   15       2     17
```

0 Fail / 0 Error. The 2 Broken are `aqua: ambiguities` and `no_implicit_imports` (both -> #71). Core group unaffected (28 pass + 2 pre-existing broken in core_tests.jl, 11 alloc_tests). Runic clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)