### PR TITLE
Document public API: add docstrings + docs entries

### DIFF
--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -1,0 +1,13 @@
+name: Documentation
+
+on:
+  push:
+    branches:
+      - main
+    tags: '*'
+  pull_request:
+
+jobs:
+  build:
+    uses: "SciML/.github/.github/workflows/documentation.yml@v1"
+    secrets: "inherit"

--- a/README.md
+++ b/README.md
@@ -177,13 +177,17 @@ b = randn(n)
 
 ## Public API
 
-For documentation of the public API, please use the REPL help mode.
+The public API is documented at
+[docs.sciml.ai/FastAlmostBandedMatrices](https://docs.sciml.ai/FastAlmostBandedMatrices/stable/),
+and each name is documented in the REPL help mode as well.
 
 ```
 AlmostBandedMatrix
 bandpart
 fillpart
 exclusive_bandpart
+almostbandwidths
+almostbandedrank
 finish_part_setindex!
 ```
 

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,0 +1,6 @@
+[deps]
+Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+FastAlmostBandedMatrices = "9d29842c-ecb8-4973-b1e9-a27b1157504e"
+
+[compat]
+Documenter = "1"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,0 +1,23 @@
+using Documenter, FastAlmostBandedMatrices
+
+makedocs(;
+    sitename = "FastAlmostBandedMatrices.jl",
+    authors = "Avik Pal et al.",
+    modules = [FastAlmostBandedMatrices],
+    clean = true,
+    doctest = false,
+    linkcheck = false,
+    checkdocs = :exports,
+    format = Documenter.HTML(;
+        canonical = "https://docs.sciml.ai/FastAlmostBandedMatrices/stable/"
+    ),
+    pages = [
+        "Home" => "index.md",
+        "API" => "api.md",
+    ]
+)
+
+deploydocs(;
+    repo = "github.com/SciML/FastAlmostBandedMatrices.jl.git",
+    push_preview = true
+)

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -1,0 +1,30 @@
+# [API](@id API)
+
+The following names make up the public API of FastAlmostBandedMatrices.jl.
+
+## Matrix Type
+
+```@docs
+AlmostBandedMatrix
+```
+
+## Accessing the Parts
+
+```@docs
+bandpart
+fillpart
+exclusive_bandpart
+```
+
+## Querying Structure
+
+```@docs
+almostbandwidths
+almostbandedrank
+```
+
+## Mutation Helpers
+
+```@docs
+finish_part_setindex!
+```

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,0 +1,53 @@
+# FastAlmostBandedMatrices.jl
+
+A fast implementation of Almost Banded Matrices in Julia. Primarily developed for use in
+[BoundaryValueDiffEq.jl](https://github.com/SciML/BoundaryValueDiffEq.jl).
+
+An almost banded matrix is a banded matrix together with a low-rank "fill" part occupying its
+leading rows. Storing and factorizing the two parts separately allows QR factorizations and
+linear solves that are much faster than treating the matrix as dense or sparse.
+
+[SemiseparableMatrices.jl](https://github.com/JuliaLinearAlgebra/SemiseparableMatrices.jl)
+provides an alternate implementation of almost banded matrices, but that had considerable
+overhead for this use-case. This implementation borrows a lot of details from that
+repository.
+
+## Installation
+
+```julia
+using Pkg
+Pkg.add("FastAlmostBandedMatrices")
+```
+
+## Basic Construction and Usage
+
+```julia
+using FastAlmostBandedMatrices, LinearAlgebra
+
+m = 2  # Fill rank
+n = 10 # Matrix dimension
+
+# Create an almost banded matrix.
+# brand(T, m, n, lower_bandwidth, upper_bandwidth) creates a random banded matrix.
+A = AlmostBandedMatrix(brand(Float64, n, n, m + 1, m), rand(Float64, m, n))
+
+# Query matrix properties
+almostbandwidths(A)  # Returns (3, 2) - the bandwidths of the banded part
+almostbandedrank(A)  # Returns 2 - the rank of the fill part
+
+# Access the parts
+B = bandpart(A)       # Get the banded part
+F = fillpart(A)       # Get the fill part (low-rank correction)
+
+# Solve linear systems efficiently
+b = rand(n)
+x = A \ b             # Uses a specialized QR factorization
+
+# QR factorization
+fact = qr(A)
+Q, R = fact.Q, fact.R
+```
+
+## Public API
+
+See the [API](@ref) page for the documented public interface.

--- a/src/FastAlmostBandedMatrices.jl
+++ b/src/FastAlmostBandedMatrices.jl
@@ -234,7 +234,35 @@ end
 
 @inline almostbandwidths(_, A) = bandwidths(bandpart(A))
 @inline almostbandedrank(_, A) = size(fillpart(A), 1)
+
+"""
+    almostbandwidths(A)
+
+Return the bandwidths `(l, u)` of the banded part of the `AlmostBandedMatrix` `A`, where `l`
+is the number of sub-diagonals and `u` is the number of super-diagonals of
+[`bandpart(A)`](@ref).
+
+# Example
+```julia
+A = AlmostBandedMatrix(brand(Float64, 10, 10, 3, 2), rand(Float64, 2, 10))
+almostbandwidths(A)  # Returns (3, 2)
+```
+"""
 @inline almostbandwidths(A) = almostbandwidths(MemoryLayout(typeof(A)), A)
+
+"""
+    almostbandedrank(A)
+
+Return the rank of the fill part of the `AlmostBandedMatrix` `A`, i.e. the number of rows of
+[`fillpart(A)`](@ref). This is also the number of leading rows of the banded part that
+overlap with the fill part.
+
+# Example
+```julia
+A = AlmostBandedMatrix(brand(Float64, 10, 10, 3, 2), rand(Float64, 2, 10))
+almostbandedrank(A)  # Returns 2
+```
+"""
 @inline almostbandedrank(A) = almostbandedrank(MemoryLayout(typeof(A)), A)
 
 @inline Base.size(A::AlmostBandedMatrix) = size(A.bands)


### PR DESCRIPTION
## Summary

Every public/exported name of FastAlmostBandedMatrices.jl now has **both** a docstring documenting its interface **and** a rendered-docs entry.

### Docstrings added

An authoritative check (`REPL.doc` on each exported binding) found two public functions with no docstring:

- `almostbandwidths` — now documents the `(l, u)` bandwidths of the banded part.
- `almostbandedrank` — now documents the fill-part rank (number of leading overlapping rows).

The other five public names (`AlmostBandedMatrix`, `bandpart`, `fillpart`, `exclusive_bandpart`, `finish_part_setindex!`) already had docstrings.

### Rendered docs added

The repo previously had **no `docs/` directory**, so none of the public names appeared in rendered documentation. This PR adds a standard Documenter site:

- `docs/Project.toml`, `docs/make.jl`, `docs/src/index.md`, `docs/src/api.md`.
- `docs/src/api.md` has `@docs` blocks covering all seven public names.
- `docs/make.jl` sets `checkdocs = :exports`, so the build **errors** if any exported name lacks a docstring or is missing from the manual (no `warnonly`).
- `.github/workflows/Documentation.yml` (SciML centralized documentation caller) builds and deploys the site.

### Validation

Built the docs locally with `julia --project=docs docs/make.jl` on Julia 1.12:

- Build exits 0; all seven `@docs` entries resolve (no "docstring not found" / "missing docs" errors).
- Verified the generated `docs/build/api/index.html` contains all seven names.
- Re-checked with `REPL.doc` that every public name now has a docstring (`ALL_DOCUMENTED=true`).
- Runic clean on changed `.jl` files.

---

Please ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)