### PR TITLE
Bump version to 0.1.8

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "FastAlmostBandedMatrices"
 uuid = "9d29842c-ecb8-4973-b1e9-a27b1157504e"
 authors = ["Avik Pal"]
-version = "0.1.7"
+version = "0.1.8"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"


### PR DESCRIPTION
Automated patch version bump (0.1.7 -> 0.1.8) to release unreleased commits on `main` via JuliaRegistrator.