### PR TITLE
Bump FastAlmostBandedMatrices to v0.1.10

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "FastAlmostBandedMatrices"
 uuid = "9d29842c-ecb8-4973-b1e9-a27b1157504e"
 authors = ["Avik Pal"]
-version = "0.1.9"
+version = "0.1.10"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"


### PR DESCRIPTION
Bumps `FastAlmostBandedMatrices` **v0.1.9 → v0.1.10** (patch) so the accumulated unreleased `src/` changes on `main` can be registered.

**Rationale:** Update QA to SciMLTesting 2.4 (#79) (docs/QA/compat/internal; no public API or behavior break)

Part of a sweep of SciML packages whose source changed since their last registered version without a version bump.

> [!NOTE]
> Please ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)